### PR TITLE
Fix probe values.

### DIFF
--- a/k8s/simple-cluster-deployment.yml
+++ b/k8s/simple-cluster-deployment.yml
@@ -37,10 +37,10 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 10
+          initialDelaySeconds: 5
+          periodSeconds: 10
         livenessProbe:
           tcpSocket:
             port: 8080
-            initialDelaySeconds: 15
-            periodSeconds: 20
+          initialDelaySeconds: 15
+          periodSeconds: 20


### PR DESCRIPTION
The `initialDelaySeconds` and `periodSeconds` values were under `tcpSocket` and are actually part of `readinessProbe` and `livenessProbe` objects.

Before this change `kubectl apply` complains about validation errors on this file.